### PR TITLE
fix: allow for dont tracking based on user-agent

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -55,3 +55,15 @@ You can also prevent all routes that match a pattern from being tracked, by givi
     ...,
     ignored_patterns=["/.*admin.*"],
   )
+
+Ignore tracking based on user-agent regex
+-----------------------------------------
+
+You can skip tracking requests made with specific user-agents.
+
+.. code-block:: python
+
+  matomo = Matomo(
+    ...,
+    ignored_ua_patterns=[".*bot.*"],
+  )


### PR DESCRIPTION
Allow for skip tracking requests made with user-agents matching any given regex.
